### PR TITLE
fix: use correct allocator in decryption

### DIFF
--- a/src/age/format.zig
+++ b/src/age/format.zig
@@ -366,7 +366,7 @@ pub const Header = struct {
         for (self.recipients) |value| {
             value.destroy();
         }
-        test_allocator.free(self.recipients);
+        self.allocator.free(self.recipients);
     }
 };
 


### PR DESCRIPTION
Thanks for the great work!

I was trying the decryption and found `std.testing.allocator` was used in production code.